### PR TITLE
Option to provide minutes after sunrise and other minor updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ Cargo.lock
 
 # End of https://www.toptal.com/developers/gitignore/api/rust
 
-secrets.json
+.secrets

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /usr/src/homebrdige-controller
 ENV RUST_LOG=debug
 
 COPY config.json config.json
-COPY secrets.json secrets.json
 
 RUN apk update
 RUN apk add --no-cache musl-dev pkgconf libressl-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
-FROM rust:1.80.1
+FROM rust:1.80.1-alpine
 
 WORKDIR /usr/src/homebrdige-controller
 
 ENV RUST_LOG=debug
 
-COPY . .
 COPY config.json config.json
 COPY secrets.json secrets.json
 
-# RUN apk update
-# RUN apk add --no-cache musl-dev
-# RUN apk add --no-cache pkgconf openssl-dev
+RUN apk update
+RUN apk add --no-cache musl-dev pkgconf libressl-dev
 
-RUN cargo install --git "https://github.com/jhrcook/homebridge-controller" --branch dev
+RUN cargo install --git "https://github.com/jhrcook/homebridge-controller" --branch main
 
 CMD ["homebridge-controller", "config.json"]

--- a/README.md
+++ b/README.md
@@ -17,12 +17,18 @@ RUST_LOG="debug" cargo run -- config.yaml
 Download the ['compose.yaml'](./compose.yaml) and ['Dockerfile'](./Dockerfile) and run the container in the background:
 
 ```bash
+# Docker files:
 wget https://github.com/jhrcook/homebridge-controller/raw/main/Dockerfile
 wget https://github.com/jhrcook/homebridge-controller/raw/main/compose.yaml
+
+# Configuration file:
+wget https://github.com/jhrcook/homebridge-controller/raw/main/config.json
+
+# Build docker
 docker compose up -d
 ```
 
-Currently, the Dockerfile installs the `dev` branch, so you may want to change that.
+Make sure to set the Homebridge authentication environment variables in the Docker compose file.
 
 ## Programs
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,6 @@
 services:
   homebridge-controller:
     build: .
+    environment:
+      HB_USER: "<user>"
+      HB_PASSWORD: "<password>"

--- a/config.json
+++ b/config.json
@@ -1,7 +1,8 @@
 {
   "turn_morning_lights_off": {
     "duration": 5,
-    "off_time": "6:20:00",
+    "off_time": null,
+    "after_sunrise": 45,
     "active": true
   },
   "program_loop_pause": 1,

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -3,7 +3,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TurningMorningLightsOffConfig {
     pub duration: u32,
-    pub off_time: String,
+    pub off_time: Option<String>,
+    pub after_sunrise: Option<i64>,
     pub active: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,11 @@ use homebridge_controller::suntimes::SunTimes;
 use log::{error, info};
 use programs::turn_morning_lights_off::TurnMorningLightsOffProgram;
 use serde::{Deserialize, Serialize};
-use std::fs;
+use std::env::VarError;
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::Duration;
+use std::{env, fs};
 use tokio::time::sleep;
 pub mod configuration;
 pub mod homebridge;
@@ -20,15 +21,20 @@ struct Secrets {
     password: String,
 }
 
+impl Secrets {
+    fn from_env() -> Result<Self, VarError> {
+        let username = env::var("HB_USER")?;
+        let password = env::var("HB_PASSWORD")?;
+        return Ok(Self { username, password });
+    }
+}
+
 /// Automated programs controlling Homebridge accessories.
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Arguments {
     /// Configuration file.
     config: PathBuf,
-    /// Secrets file.
-    #[arg(short, long, default_value = "./secrets.json")]
-    secrets: PathBuf,
 }
 
 #[tokio::main]
@@ -44,8 +50,15 @@ async fn main() -> ExitCode {
     info!("Config:\n{:?}", config);
 
     // Secrets.
-    let secrets_file = fs::File::open(args.secrets).unwrap();
-    let secrets: Secrets = serde_json::from_reader(secrets_file).unwrap();
+    // let secrets_file = fs::File::open(args.secrets).unwrap();
+    // let secrets: Secrets = serde_json::from_reader(secrets_file).unwrap();
+    let secrets = match Secrets::from_env() {
+        Ok(s) => s,
+        Err(e) => {
+            error!("Error getting Homebridge auth values: {}.", e);
+            return ExitCode::from(4);
+        }
+    };
 
     // Create `reqwest` client.
     let client = reqwest::Client::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
+use crate::configuration::Configuration;
+use crate::homebridge::Homebridge;
+use crate::programs::turn_morning_lights_off::TurnMorningLightsOffProgram;
+use crate::suntimes::SunTimes;
 use clap::Parser;
-use configuration::Configuration;
-use homebridge::Homebridge;
-use homebridge_controller::suntimes::SunTimes;
 use log::{error, info};
-use programs::turn_morning_lights_off::TurnMorningLightsOffProgram;
 use serde::{Deserialize, Serialize};
 use std::env::VarError;
 use std::path::PathBuf;
@@ -11,9 +11,11 @@ use std::process::ExitCode;
 use std::time::Duration;
 use std::{env, fs};
 use tokio::time::sleep;
+
 pub mod configuration;
 pub mod homebridge;
 pub mod programs;
+pub mod suntimes;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct Secrets {
@@ -84,11 +86,14 @@ async fn main() -> ExitCode {
         };
 
     // Sunrise/sunset data.
-    let mut _suntimes = SunTimes::new(config.longitude, config.latitude);
+    let mut suntimes = SunTimes::new(config.longitude, config.latitude);
 
     loop {
         info!("Running program loop.");
-        match lights_off_prog.run(&client, &mut homebridge).await {
+        match lights_off_prog
+            .run(&client, &mut homebridge, &mut suntimes)
+            .await
+        {
             Ok(()) => info!("Successfully executed lights-off program."),
             Err(e) => error!("Error running programing to turn morning lights off: {}", e),
         };

--- a/src/programs/turn_morning_lights_off.rs
+++ b/src/programs/turn_morning_lights_off.rs
@@ -1,7 +1,8 @@
 use crate::homebridge::Homebridge;
+use crate::suntimes::SunTimes;
 use crate::{configuration::TurningMorningLightsOffConfig, homebridge::HBError};
-use chrono::{DateTime, Local, NaiveTime};
-use log::{debug, error, info};
+use chrono::{DateTime, Duration, Local, NaiveTime};
+use log::{debug, error, info, warn};
 
 #[derive(thiserror::Error, Debug)]
 pub enum TurnMorningLightsOffProgramError {
@@ -13,7 +14,8 @@ pub enum TurnMorningLightsOffProgramError {
 
 pub struct TurnMorningLightsOffProgram {
     pub duration: u32,
-    pub off_time: NaiveTime,
+    pub off_time: Option<NaiveTime>,
+    pub after_sunrise: Option<i64>,
     pub active: bool,
     last_turned_light_off: Option<DateTime<Local>>,
 }
@@ -23,11 +25,26 @@ impl TurnMorningLightsOffProgram {
         config: &TurningMorningLightsOffConfig,
     ) -> Result<Self, TurnMorningLightsOffProgramError> {
         info!("Creating a `TurnMorningLightsOffProgram` object.");
-        let off_time = NaiveTime::parse_from_str(&config.off_time, "%H:%M:%S").map_err(|e| {
-            TurnMorningLightsOffProgramError::ParseError(format!("Error parsing off time - {}", e))
-        })?;
+
+        if config.off_time.is_none() && config.after_sunrise.is_none() {
+            warn!("Both `off_time` and `after_sunrise` are None.")
+        } else if config.off_time.is_some() && config.after_sunrise.is_some() {
+            warn!("Both `off_time` and `after_sunrise` are provided; `off_time` takes precedence.")
+        }
+
+        let off_time: Option<NaiveTime> = match &config.off_time {
+            Some(t) => Some(NaiveTime::parse_from_str(t, "%H:%M:%S").map_err(|e| {
+                TurnMorningLightsOffProgramError::ParseError(format!(
+                    "Error parsing off time: {}",
+                    e
+                ))
+            })?),
+            None => None,
+        };
+
         Ok(TurnMorningLightsOffProgram {
             off_time,
+            after_sunrise: config.after_sunrise,
             duration: config.duration,
             active: config.active,
             last_turned_light_off: Option::None,
@@ -40,26 +57,35 @@ impl TurnMorningLightsOffProgram {
         &mut self,
         client: &reqwest::Client,
         homebridge: &mut Homebridge,
+        suntimes: &mut SunTimes,
     ) -> Result<(), TurnMorningLightsOffProgramError> {
         info!("Executing `TurnMorningLightsOffProgram`.");
         if !self.active {
-            info!("Program inactive - nothing to do.");
+            debug!("Program inactive - nothing to do.");
             return Ok(());
         }
 
         let now = Local::now();
-        info!("Now: {}", now);
+        debug!("Now: {}", now);
 
         if let Some(last_turned_off) = self.last_turned_light_off {
             if last_turned_off.date_naive() == now.date_naive() {
-                info!("Already turned off the morning light today - nothing to do.");
+                debug!("Already turned off the morning light today - nothing to do.");
                 return Ok(());
             }
         }
 
-        if now.time() < self.off_time {
-            info!("Not yet time to turn off light - nothing to do.");
-            return Ok(());
+        if let Some(off_time) = self.off_time {
+            if now.time() < off_time {
+                debug!("Not yet time to turn off light - nothing to do.");
+                return Ok(());
+            }
+        } else if let Some(after_sunrise) = self.after_sunrise {
+            let sunrise = suntimes.sunrise(client).await;
+            if now.time() < sunrise.time() + Duration::minutes(after_sunrise) {
+                debug!("Not yet time to turn off light - nothing to do.");
+                return Ok(());
+            }
         }
 
         info!("After registered off-time, attempting to turn the light off.");
@@ -67,6 +93,7 @@ impl TurnMorningLightsOffProgram {
             .turn_off_bed_light(client)
             .await
             .map_err(TurnMorningLightsOffProgramError::HomebridgeInteraction)?;
+        self.last_turned_light_off = Some(now);
         Ok(())
     }
 }

--- a/src/suntimes.rs
+++ b/src/suntimes.rs
@@ -1,5 +1,5 @@
-use chrono::{DateTime, Local, NaiveTime, Utc};
-use log::{debug, error, info};
+use chrono::{DateTime, Local, Utc};
+use log::{debug, error};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
- Option to provide the number of minutes after sunrise instead of the exact time to turn off the morning bed lights.
- Move Homebridge authentication to environment variables instead of a secrets file (closes #6).
- Docker uses Alpine version of Rust container as base (closes #7).